### PR TITLE
trap possible PostgreSQL error

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -172,12 +172,12 @@ function ShowServiceRequestDetails(mapPoint, attributes) {
     try {
         selectedRequestStatus = dojo.string.substitute(status, attributes);
     }
-	catch (e) {
-	/*PostgreSQL only supports lowercase fieldnames.  
-    if casing doesn't match exactly, an unintelligible error will be thrown in the API source*/
-	    console.log("Error encountered during query: Check both the case and spelling of the Status field within config.js");
-		return
-	}
+    catch (e) {
+        /*PostgreSQL only supports lowercase fieldnames.
+        if casing doesn't match exactly, an unintelligible error will be thrown in the API source*/
+        console.log("Error encountered during query: Check both the case and spelling of the Status field within config.js");
+        return
+    }
     map.getLayer(tempGraphicsLayerId).clear();
 
     setTimeout(function () {

--- a/js/utils.js
+++ b/js/utils.js
@@ -169,14 +169,20 @@ function ShowServiceRequestDetails(mapPoint, attributes) {
             }
         }
     }
-    try {
+    try {   
         selectedRequestStatus = dojo.string.substitute(status, attributes);
     }
-    catch (e) {
-        /*PostgreSQL only supports lowercase fieldnames.
-        if casing doesn't match exactly, an unintelligible error will be thrown in the API source*/
-        console.log("Error encountered during query: Check both the case and spelling of the Status field within config.js");
-        return
+    catch (e) {		
+        var i;		
+        for (i in attributes) {	    	
+            /*if the casing for 'Status' in config.js isn't correct, 
+            make sure to use the casing from the service itself,*/			
+            var casedStatus = "${" + i + "}";
+            if (status.toUpperCase() === casedStatus.toUpperCase()) {
+                selectedRequestStatus = dojo.string.substitute(casedStatus, attributes);
+                break
+            }			
+        }	
     }
     map.getLayer(tempGraphicsLayerId).clear();
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -169,8 +169,15 @@ function ShowServiceRequestDetails(mapPoint, attributes) {
             }
         }
     }
-
-    selectedRequestStatus = dojo.string.substitute(status, attributes);
+    try {
+        selectedRequestStatus = dojo.string.substitute(status, attributes);
+    }
+	catch (e) {
+	/*PostgreSQL only supports lowercase fieldnames.  
+    if casing doesn't match exactly, an unintelligible error will be thrown in the API source*/
+	    console.log("Error encountered during query: Check both the case and spelling of the Status field within config.js");
+		return
+	}
     map.getLayer(tempGraphicsLayerId).clear();
 
     setTimeout(function () {


### PR DESCRIPTION
this is a proposed fix to trap an error most likely encountered by PostgreSQL users who failed to update the the config.js reflect the mandatory lowercasing enforced for fields in that database.

prior to the change, an obscure API error is thrown to the console and the progress wheel spins indefinitely when a user attempts to identify an existing service request.
